### PR TITLE
[DISCUSSION] Passing entire UPDATED state in handleFail handleSuccess

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fetch-normalize-data",
   "description": "A library to obtain a state of normalized data. Special fetch and reducer helpers are also provided in the export.",
-  "version": "1.9.0",
+  "version": "1.10.0-rc1",
   "private": false,
   "main": "lib/index.js",
   "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fetch-normalize-data",
   "description": "A library to obtain a state of normalized data. Special fetch and reducer helpers are also provided in the export.",
-  "version": "1.10.0-rc1",
+  "version": "1.10.0-rc2",
   "private": false,
   "main": "lib/index.js",
   "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fetch-normalize-data",
   "description": "A library to obtain a state of normalized data. Special fetch and reducer helpers are also provided in the export.",
-  "version": "1.10.0-rc2",
+  "version": "1.10.0-rc3",
   "private": false,
   "main": "lib/index.js",
   "license": "MPL-2.0",

--- a/src/fetch/errors/handleApiError.js
+++ b/src/fetch/errors/handleApiError.js
@@ -2,7 +2,7 @@ import { failData } from '../../reducer/actionCreators'
 import { API_ERROR } from './error_codes'
 
 export function handleApiError(reducer, payload, config) {
-  const [state, dispatch] = reducer
+  const { dispatch, getState } = reducer
   const { handleFail } = config
 
   payload['error_type'] = API_ERROR
@@ -10,7 +10,7 @@ export function handleApiError(reducer, payload, config) {
 
   if (handleFail) {
     const action = { config, payload }
-    handleFail(state, action)
+    handleFail(getState(), action)
   }
 }
 

--- a/src/fetch/errors/handleApiError.js
+++ b/src/fetch/errors/handleApiError.js
@@ -2,8 +2,7 @@ import { failData } from '../../reducer/actionCreators'
 import { API_ERROR } from './error_codes'
 
 export function handleApiError(reducer, payload, config) {
-  const [data, dispatch] = reducer
-  const state = { data }
+  const [state, dispatch] = reducer
   const { handleFail } = config
 
   payload['error_type'] = API_ERROR

--- a/src/fetch/errors/handleServerError.js
+++ b/src/fetch/errors/handleServerError.js
@@ -4,8 +4,7 @@ import { SERVER_ERROR } from './error_codes'
 export const GLOBAL_SERVER_ERROR = 'Server error. Try to to refresh the page.'
 
 export function handleServerError(reducer, error, config) {
-  const [data, dispatch] = reducer
-  const state = { data }
+  const { dispatch, getState } = reducer
   const { handleFail } = config
   const globalServerError = config.globalServerError || GLOBAL_SERVER_ERROR
 
@@ -29,7 +28,7 @@ export function handleServerError(reducer, error, config) {
 
   if (handleFail) {
     const action = { config, payload }
-    handleFail(state, action)
+    handleFail(getState(), action)
   }
 }
 

--- a/src/fetch/handleApiSuccess.js
+++ b/src/fetch/handleApiSuccess.js
@@ -1,8 +1,7 @@
 import { successData } from '../reducer/actionCreators'
 
 export function handleApiSuccess(reducer, payload, config) {
-  const [data, dispatch] = reducer
-  const state = { data }
+  const [state, dispatch] = reducer
   const { handleSuccess } = config
 
   dispatch(successData(payload, config))

--- a/src/fetch/handleApiSuccess.js
+++ b/src/fetch/handleApiSuccess.js
@@ -1,14 +1,14 @@
 import { successData } from '../reducer/actionCreators'
 
 export function handleApiSuccess(reducer, payload, config) {
-  const [state, dispatch] = reducer
+  const { dispatch, getState } = reducer
   const { handleSuccess } = config
 
   dispatch(successData(payload, config))
 
   if (handleSuccess) {
     const action = { config, payload }
-    handleSuccess(state, action)
+    handleSuccess(getState(), action)
   }
 }
 


### PR DESCRIPTION
Deux choses dans cette PR:
- on peut avoir directement dans les requestData des hooks handleFail et handleSuccess avec un accès direct à l'état de tout le state redux, ce qui peut-être utile dans le cas où les retours d'erreurs d'api sont aussi enregistrés dans un reducer, et qu'on souhaite directement les envoyer dans le retour de la fonction handleSubmit de react-final-form.
- les handleFail et handleSuccess (state,action) ont maintenant l'etat state MIS A JOUR de la requête (et plus de l'état d'avant). 

On peut alors faire ce genre de code moins verbeux pour passer les erreurs notamment:

```
const handleSubmit = formValues  =>
new Promise(resolve => dispatch(requestDate({
   apiPath: '/foos',
   body: formValues,
   handleFail: state => resolve(state.errors)
   method: 'POST'
}))))
```

NB: cette nouvelle version donc va surement casser une chose: à savoir les gestions des infinite scroller pour savoir s'il reste de la données.

AVANT on avait un code comme ça:

```
  handleSuccess: (state, action) => {
        const { payload: { data, headers } } = action
        const previousItems = selectItems(state)
        const totalItemsCount = parseInt(headers['total-data-count'], 10)
        const currentItemsCount = previousItems.length + data.length
        setHasMore(currentItemsCount < totalItemsCount)
        setThreshold(REACHABLE_THRESHOLD)
      }
```

qu'il faut changer en 
```
  handleSuccess: (state, action) => {
        const { payload: { headers } } = action
        const totalItemsCount = parseInt(headers['total-data-count'], 10)
        const currentItemsCount = selectItems(state) # c'est le state déjà updaté des nouveaux items
        setHasMore(currentItemsCount < totalItemsCount)
        setThreshold(REACHABLE_THRESHOLD)
      }
```

ce qui est plus simple en fait.

Doit marcher avec https://github.com/betagouv/redux-thunk-data/pull/10